### PR TITLE
Remove broken visualisation code

### DIFF
--- a/src/gias3/mesh/__init__.py
+++ b/src/gias3/mesh/__init__.py
@@ -17,5 +17,5 @@ This file is part of GIAS. (https://bitbucket.org/jangle/gias)
     You should have received a copy of the GNU General Public License
     along with GIAS.  If not, see <http://www.gnu.org/licenses/>..
 """
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 

--- a/src/gias3/mesh/simplemesh.py
+++ b/src/gias3/mesh/simplemesh.py
@@ -25,11 +25,7 @@ from gias3.mesh import inp
 from gias3.registration import alignment_analytic as alignment
 
 log = logging.getLogger(__name__)
-
-try:
-    from mayavi import mlab
-except ImportError:
-    log.debug('WARNING: Mayavi not installed, simpleMesh.disp will not work')
+log.debug('WARNING: Mayavi not installed, simpleMesh.disp will not work')
 
 
 def _load_simple_mesh(filename: str):
@@ -197,24 +193,6 @@ class SimpleMesh(object):
 
         inpWriter.addMesh(name, elemType, self.v, self.f)
         inpWriter.write()
-
-    def disp(self, curvature=None, figure=None, scalar=None, lim=(-0.2, 0.2)):
-        if figure is not None:
-            fig = mlab.figure()
-        else:
-            fig = figure
-
-        if scalar is not None:
-            return mlab.triangular_mesh(self.v[:, 0], self.v[:, 1], self.v[:, 2], self.f, scalars=scalar, figure=fig,
-                                        vmax=lim[1], vmin=lim[0])
-        elif curvature == 'H':
-            return mlab.triangular_mesh(self.v[:, 0], self.v[:, 1], self.v[:, 2], self.f, scalars=self.H, figure=fig,
-                                        vmax=lim[1], vmin=lim[0])
-        elif curvature == 'K':
-            return mlab.triangular_mesh(self.v[:, 0], self.v[:, 1], self.v[:, 2], self.f, scalars=self.K, figure=fig,
-                                        vmax=lim[1], vmin=lim[0])
-        else:
-            return mlab.triangular_mesh(self.v[:, 0], self.v[:, 1], self.v[:, 2], self.f, figure=fig)
 
     def dispLabel(self, labels: numpy.ndarray, figure=None):
         if figure is None:


### PR DESCRIPTION
This function uses an outdated version of _Mayavi_ and is redundant. Mesh visualisation is now handled in [GIAS3 Visualisation](https://github.com/musculoskeletal/gias3.visualisation).